### PR TITLE
Ensure users are created prior to adding ssh keys

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -208,8 +208,9 @@ resource "aws_transfer_user" "this" {
 }
 
 resource "aws_transfer_ssh_key" "this" {
-  for_each  = var.sftp_users_ssh_key
-  server_id = local.server_id
-  user_name = each.key
-  body      = each.value
+  for_each   = var.sftp_users_ssh_key
+  server_id  = local.server_id
+  user_name  = each.key
+  body       = each.value
+  depends_on = [aws_transfer_user.this]
 }


### PR DESCRIPTION
This pull request marks `aws_transfer_ssh_key.this` as `depends_on` `aws_transfer_user.this` to ensure users are created prior to adding a key. Creating a new user and applying a ssh key in the same `terraform apply` can cause an error adding the ssh key:

```
{
  "@level": "error",
  "@message": "Error: Error importing ssh public key: ResourceNotFoundException: Unknown user\n{\n  RespMetadata: {\n    StatusCode: 400,\n    RequestID: \"50e3bd07-8897-49cf-b2f2-8a1aaf6201df\"\n  },\n  Message_: \"Unknown user\",\n  Resource: \"poc-user\",\n  ResourceType: \"User\"\n}",
  "@module": "terraform.ui",
  "@timestamp": "2022-02-14T17:25:30.851471Z",
  "diagnostic": {
    "severity": "error",
    "summary": "Error importing ssh public key: ResourceNotFoundException: Unknown user\n{\n  RespMetadata: {\n    StatusCode: 400,\n    RequestID: \"50e3bd07-8897-49cf-b2f2-8a1aaf6201df\"\n  },\n  Message_: \"Unknown user\",\n  Resource: \"poc-user\",\n  ResourceType: \"User\"\n}",
    "detail": "",
    "address": "module.sftp.aws_transfer_ssh_key.this[\"poc-user\"]",
    "range": {
      "filename": ".terraform/modules/sftp/main.tf",
      "start": {
        "line": 209,
        "column": 40,
        "byte": 4711
      },
      "end": {
        "line": 209,
        "column": 41,
        "byte": 4712
      }
    },
    "snippet": {
      "context": "resource \"aws_transfer_ssh_key\" \"this\"",
      "code": "resource \"aws_transfer_ssh_key\" \"this\" {",
      "start_line": 209,
      "highlight_start_offset": 39,
      "highlight_end_offset": 40,
      "values": []
    }
  },
  "type": "diagnostic"
}
```