### PR TITLE
Adding restricted_home option and various fixes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,49 +51,6 @@ resource "aws_iam_role_policy" "logging" {
 POLICY
 }
 
-resource "aws_iam_role" "auth" {
-  count = var.identity_provider_type == "API_GATEWAY" ? 1 : 0
-  name  = "${local.name}-api-gateway-auth"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "transfer.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy" "auth" {
-  count = var.identity_provider_type == "API_GATEWAY" ? 1 : 0
-  name  = "${local.name}-api-gateway-auth"
-  role  = join(",", aws_iam_role.auth.*.id)
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-POLICY
-}
-
 resource "aws_transfer_server" "public" {
   # checkov:skip=CKV_AWS_164: Exposing server publicly depends on user
   count                  = var.sftp_type == "PUBLIC" ? 1 : 0

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ resource "aws_iam_role_policy" "logging" {
         "logs:CreateLogGroup",
         "logs:PutLogEvents"
       ],
-      "Resource": "*"
+      "Resource": "arn:aws:logs:*:*:log-group:/aws/transfer/*"
     }
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -255,7 +255,9 @@ resource "aws_iam_role_policy" "user" {
         "s3:GetObject",
         "s3:DeleteObjectVersion",
         "s3:DeleteObject",
-        "s3:GetObjectVersion"
+        "s3:GetObjectVersion",
+        "s3:GetObjectACL",
+        "s3:PutObjectACL"
       ],
       "Resource": "arn:aws:s3:::${trimsuffix(each.value, "/")}/*"
     }

--- a/main.tf
+++ b/main.tf
@@ -231,13 +231,21 @@ resource "aws_iam_role_policy" "user" {
     {
       "Sid": "AllowListingOfUserFolder",
       "Action": [
-        "s3:ListBucket",
-        "s3:GetBucketLocation"
+        "s3:ListBucket"
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::$${Transfer:HomeBucket}"
-      ]
+        "arn:aws:s3:::${split("/", trim(each.value, "/"))[0]}"
+      ],
+      "Condition": {
+          "StringLike": {
+              "s3:prefix": [
+                  "${trimsuffix(replace(each.value, "/^[^/]+\\//", ""), "/")}/*",
+                  "${trimsuffix(replace(each.value, "/^[^/]+\\//", ""), "/")}"
+              ]
+          }
+      }
+
     },
     {
       "Sid": "HomeDirObjectAccess",

--- a/main.tf
+++ b/main.tf
@@ -102,7 +102,7 @@ locals {
 }
 
 resource "aws_eip" "sftp_vpc" {
-  count = local.create_eip ? 1 : 0
+  count = local.create_eip ? length(lookup(var.endpoint_details, "subnet_ids", [])) : 0
   vpc   = true
   tags  = var.tags
 }
@@ -119,7 +119,8 @@ resource "aws_transfer_server" "vpc" {
     vpc_endpoint_id        = lookup(var.endpoint_details, "vpc_endpoint_id", null)
     subnet_ids             = lookup(var.endpoint_details, "subnet_ids", null)
     security_group_ids     = lookup(var.endpoint_details, "security_group_ids", aws_security_group.sftp_vpc.*.id)
-    address_allocation_ids = local.create_eip ? aws_eip.sftp_vpc.*.id : lookup(var.endpoint_details, "address_allocation_ids")
+    address_allocation_ids = local.create_eip ? aws_eip.sftp_vpc.*.id : lookup(var.endpoint_details, "address_allocation_ids", null)
+
   }
 
   identity_provider_type = var.identity_provider_type

--- a/vars.tf
+++ b/vars.tf
@@ -136,3 +136,9 @@ variable "tags" {
   default     = {}
   description = "A map of key value pair to assign to resources"
 }
+
+variable "restricted_home" {
+  type        = bool
+  description = "Restricts SFTP users so they can't access anything outside of their home directories"
+  default     = false
+}


### PR DESCRIPTION
# PR title

<!-- Thank you for submitting a pull request to our repo -->

## Prerequisites
- [ ] There is an open issue for the PR that you are making. If not, please open an issue to discuss the change or find an existing issue.

## What kind of change does this PR introduce? (check one)
- [x] Bug fix
- [ ] Feature Request

## Does this PR introduce a breaking change? (check one)
- [ ] Yes
- [x] No

## Description
<!-- Please include a summary of the change and/or which issue is fixed  -->

fix: restrict scope of the IAM role policy for logging
chore: remove unused resources
fix: replace users and keys on update of restricted_home since home_directory_mappings cannot be updated
feat: introduce restricted_home option
fix: grant additional S3 permissions so sftp commands work
fix: use s3:prefix to deny listing of somebody else's home directory
fix: replace logic which prevents the association of the default EIP

---

## Additional context
<!-- Add any other context or screenshots about the pull request here -->

---


